### PR TITLE
.gitignore 에 jpa buddy 플러그인의 설정 파일을 무시하도록 룰 추가

### DIFF
--- a/fastcampus-project-board/.gitignore
+++ b/fastcampus-project-board/.gitignore
@@ -7,6 +7,9 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
+### JPA Buddy
+.jpb/
+
 # User-specific stuff
 .idea/**/workspace.xml
 .idea/**/tasks.xml


### PR DESCRIPTION
intellij plugin 중 jpa 작업을 편하게 해주는
jpa buddy 라는 플러그인이 있는데,
intellij preference 에서 jpa buddy 설정을 바꾸면
이를 별도 숨김 디렉토리에 파일로 저장하는 듯 하다.
이를 확인하고 `.gitignore`에 등록함